### PR TITLE
Mark GL related Cairo interaction functions as unsafe

### DIFF
--- a/src/cairo_interaction.rs
+++ b/src/cairo_interaction.rs
@@ -10,7 +10,13 @@ use {GLContext, Rectangle, Surface, RGBA};
 
 pub trait SurfaceExt {
     fn create_region(&self) -> Option<Region>;
-    fn upload_to_gl(&self, target: i32, width: i32, height: i32, context: Option<&GLContext>);
+    unsafe fn upload_to_gl(
+        &self,
+        target: i32,
+        width: i32,
+        height: i32,
+        context: Option<&GLContext>,
+    );
 }
 
 impl SurfaceExt for cairo::Surface {
@@ -22,22 +28,26 @@ impl SurfaceExt for cairo::Surface {
         }
     }
 
-    fn upload_to_gl(&self, target: i32, width: i32, height: i32, context: Option<&GLContext>) {
+    unsafe fn upload_to_gl(
+        &self,
+        target: i32,
+        width: i32,
+        height: i32,
+        context: Option<&GLContext>,
+    ) {
         assert_initialized_main_thread!();
-        unsafe {
-            gdk_sys::gdk_cairo_surface_upload_to_gl(
-                mut_override(self.to_glib_none().0),
-                target,
-                width,
-                height,
-                context.to_glib_none().0,
-            );
-        }
+        gdk_sys::gdk_cairo_surface_upload_to_gl(
+            mut_override(self.to_glib_none().0),
+            target,
+            width,
+            height,
+            context.to_glib_none().0,
+        );
     }
 }
 
 pub trait ContextExt {
-    fn draw_from_gl(
+    unsafe fn draw_from_gl(
         &self,
         surface: &Surface,
         source: i32,
@@ -61,7 +71,7 @@ pub trait ContextExt {
 }
 
 impl ContextExt for Context {
-    fn draw_from_gl(
+    unsafe fn draw_from_gl(
         &self,
         surface: &Surface,
         source: i32,
@@ -73,19 +83,17 @@ impl ContextExt for Context {
         height: i32,
     ) {
         skip_assert_initialized!();
-        unsafe {
-            gdk_sys::gdk_cairo_draw_from_gl(
-                mut_override(self.to_glib_none().0),
-                surface.to_glib_none().0,
-                source,
-                source_type,
-                buffer_scale,
-                x,
-                y,
-                width,
-                height,
-            );
-        }
+        gdk_sys::gdk_cairo_draw_from_gl(
+            mut_override(self.to_glib_none().0),
+            surface.to_glib_none().0,
+            source,
+            source_type,
+            buffer_scale,
+            x,
+            y,
+            width,
+            height,
+        );
     }
 
     fn get_clip_rectangle(&self) -> Option<Rectangle> {

--- a/src/cairo_interaction.rs
+++ b/src/cairo_interaction.rs
@@ -8,7 +8,7 @@ use gdk_sys;
 use glib::translate::*;
 use {GLContext, Rectangle, Surface, RGBA};
 
-pub trait SurfaceExt {
+pub trait GdkCairoSurfaceExt {
     fn create_region(&self) -> Option<Region>;
     unsafe fn upload_to_gl(
         &self,
@@ -19,7 +19,7 @@ pub trait SurfaceExt {
     );
 }
 
-impl SurfaceExt for cairo::Surface {
+impl GdkCairoSurfaceExt for cairo::Surface {
     fn create_region(&self) -> Option<Region> {
         unsafe {
             from_glib_full(gdk_sys::gdk_cairo_region_create_from_surface(
@@ -46,7 +46,7 @@ impl SurfaceExt for cairo::Surface {
     }
 }
 
-pub trait ContextExt {
+pub trait GdkCairoContextExt {
     unsafe fn draw_from_gl(
         &self,
         surface: &Surface,
@@ -70,7 +70,7 @@ pub trait ContextExt {
     fn add_region(&self, region: &Region);
 }
 
-impl ContextExt for Context {
+impl GdkCairoContextExt for Context {
     unsafe fn draw_from_gl(
         &self,
         surface: &Surface,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,5 +6,5 @@
 
 pub use auto::traits::*;
 
-pub use cairo_interaction::{ContextExt, SurfaceExt};
+pub use cairo_interaction::{GdkCairoContextExt, GdkCairoSurfaceExt};
 pub use draw_context::DrawContextExtManual;


### PR DESCRIPTION
They take random integers for GL resources, which are basically like
pointers and must be taken care of to be correct and valid